### PR TITLE
Fix missing inputs for v4 datasets

### DIFF
--- a/fern/apis/v5/openapi/examples/create_dataset_request.json
+++ b/fern/apis/v5/openapi/examples/create_dataset_request.json
@@ -18,6 +18,6 @@
       }
     }
   ],
-  "action": "add",
+  "action": "set",
   "commit_message": "Add two new questions and answers"
 }

--- a/fern/pages/guides/create-datasets/create-dataset.mdx
+++ b/fern/pages/guides/create-datasets/create-dataset.mdx
@@ -103,6 +103,7 @@ data = [
             }
         ],
         "target": {"feature": "evaluations", "issue": "needs step-by-step guide"},
+        "inputs": {},
     },
     {
         "messages": [
@@ -115,6 +116,7 @@ data = [
             "feature": "fine-tuning",
             "issue": "process explanation and best practices",
         },
+        "inputs": {},
     },
 ]
 ```

--- a/fern/pages/guides/evaluate/set-up-evaluations.mdx
+++ b/fern/pages/guides/evaluate/set-up-evaluations.mdx
@@ -255,6 +255,7 @@ data = [
             }
         ],
         "target": {"feature": "evaluations", "issue": "needs step-by-step guide"},
+        "inputs": {},
     },
     {
         "messages": [
@@ -267,6 +268,7 @@ data = [
             "feature": "fine-tuning",
             "issue": "process explanation and best practices",
         },
+        "inputs": {},
     },
 ]
 


### PR DESCRIPTION
We don't suggest to pass in an empty dict for inputs here but it's a required field. The documentation must be lacking from when it was added. The issue was hit by a user so fixing for the next time. 