### PR TITLE
Fix links back

### DIFF
--- a/fern/versions/v4.yml
+++ b/fern/versions/v4.yml
@@ -19,11 +19,11 @@ navigation:
         slug: getting-started
         contents:
           - page: Overview
-            slug: getting-started/overview
+            slug: overview
             path: ../pages/getting-started/overview.mdx
           - page: Why Humanloop?
             path: ../pages/getting-started/why-humanloop.mdx
-            slug: getting-started/why-humanloop
+            slug: why-humanloop
           - page: Quickstart Tutorial
             path: ../pages/getting-started/quickstart-tutorial.mdx
             slug: tutorials/quickstart


### PR DESCRIPTION
docs.humanloop.com -> /docs/overview which now 404s

and this is a permanent redirect so need to preserve it