### PR TITLE
Adding changelog for get all deployed files

### DIFF
--- a/fern/changelog/2024-08-30.md
+++ b/fern/changelog/2024-08-30.md
@@ -1,0 +1,3 @@
+## Get All Deployed Versions via API
+
+We've introduced a new Files API in our v5 API resources that lets you query all files simultaneously. This is useful when managing your workflows on Humanloop and you wish to find all files that match specific criteria, such as having a deployment in a specific environment. Some of the supported filters to search with are file name, file type, and deployed environments. If you find there are additional access patterns you'd find useful, please reach out and let us know.


### PR DESCRIPTION
Bit late, but adding a changelog for the new Files endpoint that allows users to query by environment name. 